### PR TITLE
Small package changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ This repo contains bare-bones code for creating a [Rollup plugin](https://rollup
 Clone this repository and install its dependencies:
 
 ```bash
-mkdir rollup-starter-plugin
-cd rollup-starter-plugin
-npx degit https://github.com/rollup/rollup-starter-plugin
+npx degit https://github.com/rollup/rollup-starter-plugin my-plugin
+cd my-plugin
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Rollup starter plugin",
   "main": "dist/rollup-starter-plugin.cjs.js",
   "module": "dist/rollup-starter-plugin.es.js",
-  "jsnext:main": "dist/rollup-starter-plugin.es.js",
   "files": [
-    "src",
     "dist"
   ],
   "keywords": [


### PR DESCRIPTION
Just some things I came across, different opinions welcome!

- This removes "jsnext:main" from the repo as by now, all tools have converged on using the "module" field and therefore the use of "jsnext:main" is discouraged and could even be confusing. Also, in contrast to the module field, the value is not linked to the rollup config (nice touch by the way).
- This removes the "src" folder from the distributed bundle. This is definitely open for discussion. My rationale is that users of a plugin already have a CJS and ESM version of it so why would they need a third version? Should reduce download size.
- Apparently, "degit" supports directly specifying a directory which makes the instructions one line shorter
